### PR TITLE
Add tests to autoini package and update its logic

### DIFF
--- a/autoini/autoini.go
+++ b/autoini/autoini.go
@@ -53,8 +53,9 @@ func getKey(key string, optional bool, cfg *ini.File) (valueInConfig *ini.Key, e
 }
 
 type Setter func(value reflect.Value, valueInConfig *ini.Key) (err error)
+type DefaultHandler[Implementation implementationChecker] func(def Implementation, key string, value reflect.Value) (err error)
 
-func setGenericKey[T Configurable, Implementation implementationChecker](result T, key string, value reflect.Value, cfg *ini.File, setter Setter, defaultHandler func(def Implementation, key string, value reflect.Value) (err error)) (err error) {
+func setGenericKey[T Configurable, Implementation implementationChecker](result T, key string, value reflect.Value, cfg *ini.File, setter Setter, defaultHandler DefaultHandler[Implementation]) (err error) {
 	valueInConfig, err := getKey(key, isOptional(result, key), cfg)
 	if err != nil {
 		return err

--- a/autoini/autoini_test.go
+++ b/autoini/autoini_test.go
@@ -1,0 +1,39 @@
+package autoini
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type SimpleValue struct {
+	value bool
+}
+
+type Values struct {
+	value1 bool
+}
+
+func (v Values) Optional(key string) bool {
+	return false
+}
+
+func TestReadIniInvalid(t *testing.T) {
+	var assert = assert.New(t)
+
+	var ini, err = ReadIni[SimpleValue]("./test/a.ini")
+	assert.NotEqual(nil, err, "Was able to read an invalid ini file")
+	assert.Contains(err, "key-value delimiter not found")
+	assert.Equal(false, ini.value, "Incorrect value returned")
+
+	ini, err = ReadIni[SimpleValue]("./test/b.ini")
+	assert.NotEqual(nil, err, "Was able to read an ini file without the required value")
+	assert.Contains(err, "key-value delimiter not found")
+	assert.Equal(false, ini.value, "Incorrect value returned")
+}
+
+// func TestReadIniValid(t *testing.T) {
+// 	var assert = assert.New(t)
+
+// 	var ini = ReadIni[Values]()
+// }

--- a/autoini/autoini_test.go
+++ b/autoini/autoini_test.go
@@ -1,6 +1,7 @@
 package autoini
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,11 +16,43 @@ type SimpleValue struct {
 }
 
 type Values struct {
-	value1 bool
+	Value1 bool
+	Value2 int
+	Value3 string
 }
 
 func (v Values) Optional(key string) bool {
 	return false
+}
+
+type ValuesDefault struct {
+	Value1 bool
+	Value2 int
+	Value3 string
+}
+
+func (v ValuesDefault) Optional(key string) bool {
+	return true
+}
+
+func (v ValuesDefault) DefaultString(key string) string {
+	return "string value"
+}
+
+func (v ValuesDefault) DefaultInt(key string) int {
+	return 123
+}
+
+func (v ValuesDefault) DefaultBool(key string) bool {
+	return false
+}
+
+func (v ValuesDefault) PostInit() (err error) {
+	if v.Value2 == 42 {
+		return errors.New("42 is not allowed")
+	}
+
+	return nil
 }
 
 func TestReadIniInvalid(t *testing.T) {
@@ -27,25 +60,41 @@ func TestReadIniInvalid(t *testing.T) {
 
 	var ini1, err = ReadIni[SimpleValueNotExported]("./test/a.ini")
 	assert.NotEqual(nil, err, "Was able to read an invalid ini file")
-	var errorString = err.Error()
-	assert.Contains(errorString, "key-value delimiter not found")
+	assert.Contains(err.Error(), "key-value delimiter not found")
 	assert.Equal(false, ini1.value, "Incorrect value returned")
 
 	ini1, err = ReadIni[SimpleValueNotExported]("./test/b.ini")
 	assert.NotEqual(nil, err, "Was able to read an invalid ini file")
-	errorString = err.Error()
-	assert.Contains(errorString, "field does not exist or is not exported: value")
+	assert.Contains(err.Error(), "field does not exist or is not exported: value")
 	assert.Equal(false, ini1.value, "Incorrect value returned")
 
 	ini2, err := ReadIni[SimpleValue]("./test/b.ini")
 	assert.NotEqual(nil, err, "Was able to read an ini file without the required value")
-	errorString = err.Error()
-	assert.Contains(errorString, "non-optional config file key not found: Value")
+	assert.Contains(err.Error(), "non-optional config file key not found: Value")
 	assert.Equal(false, ini2.Value, "Incorrect value returned")
 }
 
-// func TestReadIniValid(t *testing.T) {
-// 	var assert = assert.New(t)
+func TestReadIniValid(t *testing.T) {
+	var assert = assert.New(t)
 
-// 	var ini = ReadIni[Values]()
-// }
+	var ini, err = ReadIni[Values]("./test/c.ini")
+	assert.Equal(nil, err, "Was not able to read a valid ini file")
+	assert.Equal(true, ini.Value1, "Incorrect Value1 returned")
+	assert.Equal(42, ini.Value2, "Incorrect Value2 returned")
+	assert.Equal("hello world", ini.Value3, "Incorrect Value3 returned")
+}
+
+func TestReadIniOptionalImplementationsValid(t *testing.T) {
+	var assert = assert.New(t)
+
+	var ini, err = ReadIni[ValuesDefault]("./test/empty.ini")
+	assert.Equal(nil, err, "Was not able to read a valid ini file")
+	assert.Equal(false, ini.Value1, "Incorrect Value1 returned")
+	assert.Equal(123, ini.Value2, "Incorrect Value2 returned")
+	assert.Equal("string value", ini.Value3, "Incorrect Value3 returned")
+
+	ini, err = ReadIni[ValuesDefault]("./test/c.ini")
+	assert.NotEqual(nil, err, "PostInit did not return an error")
+	assert.Contains(err.Error(), "42 is not allowed")
+	assert.Equal(42, ini.Value2, "Incorrect new Value2 returned")
+}

--- a/autoini/autoini_test.go
+++ b/autoini/autoini_test.go
@@ -6,8 +6,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type SimpleValue struct {
+type SimpleValueNotExported struct {
 	value bool
+}
+
+type SimpleValue struct {
+	Value bool
 }
 
 type Values struct {
@@ -21,15 +25,23 @@ func (v Values) Optional(key string) bool {
 func TestReadIniInvalid(t *testing.T) {
 	var assert = assert.New(t)
 
-	var ini, err = ReadIni[SimpleValue]("./test/a.ini")
+	var ini1, err = ReadIni[SimpleValueNotExported]("./test/a.ini")
 	assert.NotEqual(nil, err, "Was able to read an invalid ini file")
-	assert.Contains(err, "key-value delimiter not found")
-	assert.Equal(false, ini.value, "Incorrect value returned")
+	var errorString = err.Error()
+	assert.Contains(errorString, "key-value delimiter not found")
+	assert.Equal(false, ini1.value, "Incorrect value returned")
 
-	ini, err = ReadIni[SimpleValue]("./test/b.ini")
+	ini1, err = ReadIni[SimpleValueNotExported]("./test/b.ini")
+	assert.NotEqual(nil, err, "Was able to read an invalid ini file")
+	errorString = err.Error()
+	assert.Contains(errorString, "field does not exist or is not exported: value")
+	assert.Equal(false, ini1.value, "Incorrect value returned")
+
+	ini2, err := ReadIni[SimpleValue]("./test/b.ini")
 	assert.NotEqual(nil, err, "Was able to read an ini file without the required value")
-	assert.Contains(err, "key-value delimiter not found")
-	assert.Equal(false, ini.value, "Incorrect value returned")
+	errorString = err.Error()
+	assert.Contains(errorString, "non-optional config file key not found: Value")
+	assert.Equal(false, ini2.Value, "Incorrect value returned")
 }
 
 // func TestReadIniValid(t *testing.T) {

--- a/autoini/test/a.ini
+++ b/autoini/test/a.ini
@@ -1,0 +1,1 @@
+invalid abcd

--- a/autoini/test/b.ini
+++ b/autoini/test/b.ini
@@ -1,0 +1,1 @@
+value_other=true

--- a/autoini/test/c.ini
+++ b/autoini/test/c.ini
@@ -1,0 +1,4 @@
+value1=true
+value2=42
+value3=3.14
+value5="hello world"

--- a/autoini/test/c.ini
+++ b/autoini/test/c.ini
@@ -1,4 +1,3 @@
-value1=true
-value2=42
-value3=3.14
-value5="hello world"
+Value1=true
+Value2=42
+Value3="hello world"

--- a/main.go
+++ b/main.go
@@ -12,8 +12,10 @@ import (
 )
 
 func main() {
-	var config = autoini.ReadIni[Config]("config.ini")
-	fmt.Println(config)
+	var config, err = autoini.ReadIni[Config]("config.ini")
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	mongo, err := mongodb.NewMongoDB(config.MongodbConnectionUrl, config.DatabaseName)
 	if err != nil {

--- a/mongodb/mongodb.go
+++ b/mongodb/mongodb.go
@@ -107,7 +107,6 @@ func (m *MongoDB) GetLastDocumentFiltered(collection string, sortedKey string, f
 	}
 	opts := options.FindOne().SetSort(bson.D{{Key: sortedKey, Value: 1}}).SetSkip(count - 1)
 
-	// TODO: Return un-decoded result
 	result = mongoCollection.FindOne(ctx, filter, opts)
 	if result.Err() != nil {
 		return result, result.Err()

--- a/query.go
+++ b/query.go
@@ -1,6 +1,8 @@
 package main
 
-import "log"
+import (
+	"errors"
+)
 
 type QueryConfig struct {
 	Name                   string // Internal only
@@ -71,11 +73,12 @@ func (q QueryConfig) DefaultBool(key string) bool {
 	return false
 }
 
-func (q *QueryConfig) PostInit() {
+func (q *QueryConfig) PostInit() (err error) {
 	if q.ResultType != "string" && q.ResultType != "number" {
-		log.Fatalf("Invalid result type %v. Only \"string\" and \"number\" result types are supported", q.ResultType)
+		return errors.New("Invalid result type " + q.ResultType + ". Only \"string\" and \"number\" result types are supported")
 	}
 	if q.RequestBackend != "chrome" && q.RequestBackend != "go" {
-		log.Fatalf("Invalid request backend %v. Only \"chrome\" and \"go\" request backends are supported", q.RequestBackend)
+		return errors.New("Invalid request backend " + q.RequestBackend + ". Only \"chrome\" and \"go\" request backends are supported")
 	}
+	return
 }

--- a/tracker.go
+++ b/tracker.go
@@ -193,9 +193,12 @@ func StartTrackers(queries []string, globalConfig Config, mongo mongodb.MongoDB,
 		for _, configPath := range queries {
 			var threadStopResponse = make(chan any)
 			stopChannels = append(stopChannels, threadStopResponse)
-			var config = autoini.ReadIni[QueryConfig](configPath)
+			var config, err = autoini.ReadIni[QueryConfig](configPath)
+			if err != nil {
+				log.Fatal(err)
+			}
 			config.Name = GetFileNameWithoutExtension(configPath)
-			var err = mongo.CreateCollection(config.Name)
+			err = mongo.CreateCollection(config.Name)
 			if err != nil {
 				log.Fatal(err)
 			}


### PR DESCRIPTION
- Updates `autoini` package logic to use a generic implementation for setting values and reusing it for each type
- `autoini` package now returns errors instead of exiting the application
- Adds validation tests for `autoini` package